### PR TITLE
Auto start when running WhiteBread.run

### DIFF
--- a/lib/mix/tasks/white_bread.run.ex
+++ b/lib/mix/tasks/white_bread.run.ex
@@ -6,6 +6,7 @@ defmodule Mix.Tasks.WhiteBread.Run do
 
   def run(argv) do
     {options, arguments, _} = OptionParser.parse(argv)
+    start_app(argv)
     case arguments do
       [context_name | _ ] ->
         context_from_string(context_name) |> run("features/", options)
@@ -13,6 +14,12 @@ defmodule Mix.Tasks.WhiteBread.Run do
         load_default_context |> run("features/", options)
     end
 
+  end
+
+  def start_app(argv) do
+    unless "--no-start" in argv do
+      Mix.Task.run "app.start", argv
+    end
   end
 
   def load_default_context do


### PR DESCRIPTION
Fixes #9 

Adds option ```--no-start``` to disable if required.
 
