### PR TITLE
Adding color to output

### DIFF
--- a/lib/white_bread/final_result_printer.ex
+++ b/lib/white_bread/final_result_printer.ex
@@ -1,5 +1,6 @@
 defmodule WhiteBread.FinalResultPrinter do
   alias WhiteBread.Formatter.FailedStep
+  alias WhiteBread.Outputers.Style
 
   def puts(result) do
     IO.puts result
@@ -30,6 +31,7 @@ defmodule WhiteBread.FinalResultPrinter do
 
     failing_count = Enum.count(failing_scenarios)
     "#{failing_count} scenario failed for #{feature.name}\n" <> scenerios_text
+    |> Style.failed
   end
 
   defp failing_scenerio_text(scenario_faliure, step_helper) do

--- a/lib/white_bread/final_result_printer.ex
+++ b/lib/white_bread/final_result_printer.ex
@@ -30,8 +30,9 @@ defmodule WhiteBread.FinalResultPrinter do
       |> Enum.join("\n")
 
     failing_count = Enum.count(failing_scenarios)
-    "#{failing_count} scenario failed for #{feature.name}\n" <> scenerios_text
-    |> Style.failed
+    Style.failed "#{failing_count} scenario failed for" <>
+    " #{feature.name}\n" <> scenerios_text
+
   end
 
   defp failing_scenerio_text(scenario_faliure, step_helper) do

--- a/lib/white_bread/formatter/failed_step.ex
+++ b/lib/white_bread/formatter/failed_step.ex
@@ -9,8 +9,8 @@ defimpl WhiteBread.Formatter.FailedStep, for: Atom do
   def text(:missing_step, step, _error) do
     %{text: step_text} = step
     code_to_implement = CodeGenerator.Step.regex_code_for_step(step)
-    Style.info "undefined step: #{step_text}" <>
-    " implement with\n\n" <> code_to_implement
+    Style.info "undefined step: #{step_text}"
+    <> " implement with\n\n" <> code_to_implement
   end
 
   def text(:no_clause_match, step, error) do

--- a/lib/white_bread/formatter/failed_step.ex
+++ b/lib/white_bread/formatter/failed_step.ex
@@ -9,14 +9,16 @@ defimpl WhiteBread.Formatter.FailedStep, for: Atom do
   def text(:missing_step, step, _error) do
     %{text: step_text} = step
     code_to_implement = CodeGenerator.Step.regex_code_for_step(step)
-    Style.info "undefined step: #{step_text} implement with\n\n" <> code_to_implement
+    Style.info "undefined step: #{step_text}" <>
+    " implement with\n\n" <> code_to_implement
   end
 
   def text(:no_clause_match, step, error) do
     %{text: step_text} = step
     {_clause_match_error, stacktrace} = error
     trace_message = Exception.format_stacktrace(stacktrace)
-    Style.failed "unable to match clauses: #{step_text}:\ntrace:\n#{trace_message}"
+    Style.failed "unable to match clauses: #{step_text}:\n" <>
+    "trace:\n#{trace_message}"
   end
 
   def text(:other_failure, step, {other_failure, stacktrace}) do

--- a/lib/white_bread/formatter/failed_step.ex
+++ b/lib/white_bread/formatter/failed_step.ex
@@ -4,25 +4,26 @@ end
 
 defimpl WhiteBread.Formatter.FailedStep, for: Atom do
   alias WhiteBread.CodeGenerator
+  alias WhiteBread.Outputers.Style
 
   def text(:missing_step, step, _error) do
     %{text: step_text} = step
     code_to_implement = CodeGenerator.Step.regex_code_for_step(step)
-    "undefined step: #{step_text} implement with\n\n" <> code_to_implement
+    Style.info "undefined step: #{step_text} implement with\n\n" <> code_to_implement
   end
 
   def text(:no_clause_match, step, error) do
     %{text: step_text} = step
     {_clause_match_error, stacktrace} = error
     trace_message = Exception.format_stacktrace(stacktrace)
-    "unable to match clauses: #{step_text}:\ntrace:\n#{trace_message}"
+    Style.failed "unable to match clauses: #{step_text}:\ntrace:\n#{trace_message}"
   end
 
   def text(:other_failure, step, {other_failure, stacktrace}) do
     %{text: step_text} = step
     trace_message = Exception.format_stacktrace(stacktrace)
     "execution failure: #{step_text}:\n" <>
-    "Exception: #{Exception.message other_failure}: \n" <>
+    Style.exception "Exception: #{Exception.message other_failure}: \n" <>
     trace_message
   end
 end

--- a/lib/white_bread/outputers/console.ex
+++ b/lib/white_bread/outputers/console.ex
@@ -1,5 +1,6 @@
 defmodule WhiteBread.Outputers.Console do
   defstruct pid: nil
+  alias WhiteBread.Outputers.Style, as: Style
 
   def start do
     pid = spawn fn -> work end
@@ -32,7 +33,7 @@ defmodule WhiteBread.Outputers.Console do
   end
 
   defp output_scenario_result({result, _result_info}, scenario) do
-    IO.puts "#{scenario.name} ---> #{result}"
+    IO.puts Style.decide_color result, "#{scenario.name} ---> #{result}"
     :ok
   end
 

--- a/lib/white_bread/outputers/console.ex
+++ b/lib/white_bread/outputers/console.ex
@@ -1,6 +1,6 @@
 defmodule WhiteBread.Outputers.Console do
   defstruct pid: nil
-  alias WhiteBread.Outputers.Style, as: Style
+  alias WhiteBread.Outputers.Style
 
   def start do
     pid = spawn fn -> work end

--- a/lib/white_bread/outputers/style.ex
+++ b/lib/white_bread/outputers/style.ex
@@ -1,35 +1,36 @@
 defmodule WhiteBread.Outputers.Style do
 
-	@style_atoms [{:failed, :red}, {:ok, :green}, {:exception, :yellow}, {:info, :blue}]
+  @style_atoms [{:failed, :red}, {:ok, :green},
+  {:exception, :yellow}, {:info, :blue}]
 
-	def decide_color(style, message) when is_atom(style) do
-		if(Keyword.has_key? @style_atoms, style) do
-			color(@style_atoms[style], message)
-		else
-			message
-		end
-	end
-	
-	def success(message) do
-		color(@style_atoms[:ok], message)
-	end
+  def decide_color(style, message) when is_atom(style) do
+    if(Keyword.has_key? @style_atoms, style) do
+      color(@style_atoms[style], message)
+    else
+      message
+    end
+  end
 
-	def failed(message) do
-		color(@style_atoms[:failed], message)
-	end
+  def success(message) do
+    color(@style_atoms[:ok], message)
+  end
 
-	def exception(message) do
-		color(@style_atoms[:exception], message)
-	end
+  def failed(message) do
+    color(@style_atoms[:failed], message)
+  end
 
-	def info(message) do
-		color(@style_atoms[:info], message)
-	end
+  def exception(message) do
+    color(@style_atoms[:exception], message)
+  end
 
-	def color(color, string_msg) do
-		[IO.ANSI.format_fragment([color], IO.ANSI.enabled?), 
-		string_msg, 
-		IO.ANSI.format_fragment(:reset, IO.ANSI.enabled?)] 
-		|> IO.iodata_to_binary
-	end
+  def info(message) do
+    color(@style_atoms[:info], message)
+  end
+
+  def color(color, string_msg) do
+    [IO.ANSI.format_fragment([color], IO.ANSI.enabled?),
+    string_msg,
+    IO.ANSI.format_fragment(:reset, IO.ANSI.enabled?)]
+    |> IO.iodata_to_binary
+  end
 end

--- a/lib/white_bread/outputers/style.ex
+++ b/lib/white_bread/outputers/style.ex
@@ -1,4 +1,14 @@
 defmodule WhiteBread.Outputers.Style do
+
+	@style_atoms [{:failed, :red}, {:ok, :green}]
+
+	def decide_color(style, message) when is_atom(style) do
+		if(Keyword.has_key? @style_atoms, style) do
+			color(@style_atoms[style], message)
+		else
+			message
+		end
+	end
 	
 	def success(message) do
 		color(:green, message)

--- a/lib/white_bread/outputers/style.ex
+++ b/lib/white_bread/outputers/style.ex
@@ -27,9 +27,9 @@ defmodule WhiteBread.Outputers.Style do
 	end
 
 	def color(color, string_msg) do
-    [IO.ANSI.format_fragment([color], IO.ANSI.enabled?), 
-    string_msg, 
-    IO.ANSI.format_fragment(:reset, IO.ANSI.enabled?)] 
-    |> IO.iodata_to_binary
-  end
+		[IO.ANSI.format_fragment([color], IO.ANSI.enabled?), 
+		string_msg, 
+		IO.ANSI.format_fragment(:reset, IO.ANSI.enabled?)] 
+		|> IO.iodata_to_binary
+	end
 end

--- a/lib/white_bread/outputers/style.ex
+++ b/lib/white_bread/outputers/style.ex
@@ -1,0 +1,17 @@
+defmodule WhiteBread.Outputers.Style do
+	
+	def success(message) do
+		color(:green, message)
+	end
+
+	def failed(message) do
+		color(:red, message)
+	end
+
+	def color(color, string_msg) do
+    [IO.ANSI.format_fragment([color], IO.ANSI.enabled?), 
+    string_msg, 
+    IO.ANSI.format_fragment(:reset, IO.ANSI.enabled?)] 
+    |> IO.iodata_to_binary
+  end
+end

--- a/lib/white_bread/outputers/style.ex
+++ b/lib/white_bread/outputers/style.ex
@@ -1,6 +1,6 @@
 defmodule WhiteBread.Outputers.Style do
 
-	@style_atoms [{:failed, :red}, {:ok, :green}]
+	@style_atoms [{:failed, :red}, {:ok, :green}, {:exception, :yellow}, {:info, :blue}]
 
 	def decide_color(style, message) when is_atom(style) do
 		if(Keyword.has_key? @style_atoms, style) do
@@ -11,11 +11,19 @@ defmodule WhiteBread.Outputers.Style do
 	end
 	
 	def success(message) do
-		color(:green, message)
+		color(@style_atoms[:ok], message)
 	end
 
 	def failed(message) do
-		color(:red, message)
+		color(@style_atoms[:failed], message)
+	end
+
+	def exception(message) do
+		color(@style_atoms[:exception], message)
+	end
+
+	def info(message) do
+		color(@style_atoms[:info], message)
 	end
 
 	def color(color, string_msg) do

--- a/lib/white_bread/runners/scenario_outline_runner.ex
+++ b/lib/white_bread/runners/scenario_outline_runner.ex
@@ -38,7 +38,8 @@ defimpl WhiteBread.Runners, for: WhiteBread.Gherkin.Elements.ScenarioOutline do
   defp report_progress(results, setup, scenario_outline) do
     failures? = results |> Enum.any?(fn {success, _} -> success != :ok end)
     success_status = if failures?, do: :failed, else: :ok
-    scenario_report ={:scenario_result, {success_status, nil}, scenario_outline}
+    scenario_report ={:scenario_result, {success_status, nil},
+    scenario_outline}
     setup.progress_reporter
       |> ProgressReporter.report(scenario_report)
     results

--- a/test/final_result_printer_test.exs
+++ b/test/final_result_printer_test.exs
@@ -40,8 +40,8 @@ defmodule WhiteBread.FinalResultPrinterTest do
 
     output = WhiteBread.FinalResultPrinter.text(result, MockStepFailure)
     assert output == """
-    1 scenario failed for feature name
-      - failing scenario --> STEP_FAILURE_TEXT
+    \e[31m1 scenario failed for feature name
+      - failing scenario --> STEP_FAILURE_TEXT\e[0m
     """
   end
 
@@ -60,8 +60,8 @@ defmodule WhiteBread.FinalResultPrinterTest do
 
     output = WhiteBread.FinalResultPrinter.text(result, MockStepFailure)
     assert output == """
-    1 scenario failed for feature name
-      - failing scenario --> Ended in a not okay state
+    \e[31m1 scenario failed for feature name
+      - failing scenario --> Ended in a not okay state\e[0m
     """
   end
 

--- a/test/formatter/failed_step_test.exs
+++ b/test/formatter/failed_step_test.exs
@@ -9,7 +9,7 @@ defmodule WhiteBread.Formatter.FailedStepTest do
     step = %{text: "failing step"}
 
     output = FailedStep.text(:no_clause_match, step, {%{}, trace})
-    assert output == "unable to match clauses: failing step:\ntrace:\n#{Exception.format_stacktrace trace}"
+    assert output == "\e[31munable to match clauses: failing step:\ntrace:\n#{Exception.format_stacktrace trace}\e[0m"
   end
 
   test "Prints out regex for a missing step" do
@@ -17,7 +17,7 @@ defmodule WhiteBread.Formatter.FailedStepTest do
     code_to_implement = CodeGenerator.Step.regex_code_for_step(step)
 
     output = FailedStep.text(:missing_step, step, :unused)
-    assert output == "undefined step: missing step implement with\n\n" <> code_to_implement
+    assert output == "\e[34mundefined step: missing step implement with\n\n" <> code_to_implement <> "\e[0m"
   end
 
   test "Prints out assestion failing steps" do
@@ -37,6 +37,6 @@ defmodule WhiteBread.Formatter.FailedStepTest do
     stacktrace = [{Module, :failure, 0, [{:file, "somefile"}, {:line, 10}]}]
 
     output = FailedStep.text(:other_failure, step, {exception, stacktrace})
-    assert output == "execution failure: #{step.text}:\nException: #{Exception.message exception}: \n#{Exception.format_stacktrace stacktrace}"
+    assert output == "execution failure: #{step.text}:\n\e[33mException: #{Exception.message exception}: \n#{Exception.format_stacktrace stacktrace}\e[0m"
   end
 end

--- a/test/outputers/style_test.exs
+++ b/test/outputers/style_test.exs
@@ -4,14 +4,22 @@ defmodule WhiteBread.Outputers.StyleTests do
 
 	test "check failed message is in `red` colour encoding" do
 		styled_binary = Style.failed("Exception was thrown")
-		assert String.contains? styled_binary, "\e[31m"
-		assert String.contains? styled_binary, "Exception"
+		assert styled_binary == "\e[31mException was thrown\e[0m"
 	end
 
 	test "check success message is in `green` colour encoding" do
 		styled_binary = Style.success("Success message")
-		assert String.contains? styled_binary, "\e[32m"
-		assert String.contains? styled_binary, "Success"
+		assert styled_binary == "\e[32mSuccess message\e[0m"
+	end
+
+	test "decide how to colour a failed message with red" do
+		styled_binary = Style.decide_color(:failed, "Exception was thrown");
+		assert String.contains? styled_binary, "\e[31m"
+	end
+
+	test "no colour style atom then return plain message" do
+		styled_binary = Style.decide_color(:no_color, "I'm just a message");
+		assert styled_binary == "I'm just a message"
 	end
 
 end

--- a/test/outputers/style_test.exs
+++ b/test/outputers/style_test.exs
@@ -1,6 +1,6 @@
 defmodule WhiteBread.Outputers.StyleTests do
 	use ExUnit.Case
-	alias WhiteBread.Outputers.Style, as: Style
+	alias WhiteBread.Outputers.Style
 
 	test "check failed message is in `red` colour encoding" do
 		styled_binary = Style.failed("Exception was thrown")

--- a/test/outputers/style_test.exs
+++ b/test/outputers/style_test.exs
@@ -1,0 +1,17 @@
+defmodule WhiteBread.Outputers.StyleTests do
+	use ExUnit.Case
+	alias WhiteBread.Outputers.Style, as: Style
+
+	test "check failed message is in `red` colour encoding" do
+		styled_binary = Style.failed("Exception was thrown")
+		assert String.contains? styled_binary, "\e[31m"
+		assert String.contains? styled_binary, "Exception"
+	end
+
+	test "check success message is in `green` colour encoding" do
+		styled_binary = Style.success("Success message")
+		assert String.contains? styled_binary, "\e[32m"
+		assert String.contains? styled_binary, "Success"
+	end
+
+end


### PR DESCRIPTION
For issue #28 

- Made a module for styling the colour of output
- Added unit tests and updated exiting tests.
- Pass in green, Failed in red, Exception in yellow, Info in blue

Example output:
![image](https://cloud.githubusercontent.com/assets/10452163/11976693/df4864a2-a972-11e5-9535-cf774e08ef30.png)
