### PR TITLE
Enable "macroless" contexts

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,9 +138,11 @@ The public interface of this library covers:
 * The exported mix command: ```mix white_bread.run```
 * The ```WhiteBread``` and ```WhiteBread.Helpers``` modules.
 * The macros exported by the ```WhiteBread.Context``` module.
+* The config.exs structure and the macros exported by the ```WhiteBread.SuiteConfiguration``` module.
 * The structures defined in ```WhiteBread.Gherkin```.
+* The location of feature and context files loaded automatically.
 
-Any changes outside of this will not be considered a BC break.
+Any changes outside of the above will not be considered a BC break. Although every effort will be made to not introduce unnecessary change in any other area.
 
 # Contribute
 Contributions more than welcome but please raise an issue first to discuss any large changes.

--- a/README.md
+++ b/README.md
@@ -94,13 +94,43 @@ After doing this rerun
 mix white_bread.run
 ```
 
-# Gherkin Syntax covered
-- [x] Features
-- [x] Step definitions: '''given''', '''when''', '''then''', '''and''' and '''but'''
-- [x] Feature backgound steps
-- [x] Scenerios
-- [x] Scenario outlines
-- [x] Tags
+# Next steps - Suites and subcontexts
+
+After following the getting started steps you may find your default context starts to get a bit large. Defining suites allows you to break your your contexts apart and assign them to specific features. You can even run one feature multiple times under different contexts. This is especially useful if you have a few different ways of accessing your software (web, rest api, command line etc.). 
+
+Suite configuration is loaded from ```features/config.exs```. Create this file then add something like:
+
+```elixir
+defmodule WhiteBread.Example.Config do
+  use WhiteBread.SuiteConfiguration
+
+  suite name:          "Default",
+        context:       WhiteBread.Example.DefaultContext,
+        feature_paths: ["features/sub_dir_one"]
+
+  suite name:          "Alternate",
+        context:       WhiteBread.Example.AlternateContext,
+        feature_paths: ["features/sub_dir_two"]
+
+  suite name:          "Alternate - Songs",
+        context:       WhiteBread.Example.AlternateContext,
+        feature_paths: ["features/sub_dir_one"],
+        tags:          ["songs"]
+end
+```
+Each suite gets run loading all the features in the given paths and running them using the specified context. Additionally the scenarios can be filtered to specific tags.
+
+It's quite likely that there will be some common steps in your contexts. These steps can be stored in a shared context then imported as a subcontext:
+```elixir
+defmodule WhiteBread.Example.DefaultContext do
+  use WhiteBread.Context
+
+  subcontext WhiteBread.Example.SharedContext
+  
+  # Rest of the context here as usual
+  #...
+end
+```
 
 # Public interface and BC breaks
 The public interface of this library covers:

--- a/features/config.exs
+++ b/features/config.exs
@@ -1,15 +1,15 @@
 defmodule WhiteBread.Example.Config do
   use WhiteBread.SuiteConfiguration
 
-  suite name:          "Default",
+  suite name:          "Default context",
         context:       WhiteBread.Example.DefaultContext,
         feature_paths: ["features/"]
 
-  suite name:          "Alternate",
+  suite name:          "Alternate context",
         context:       WhiteBread.Example.AlternateContext,
         feature_paths: ["features/"]
 
-  suite name:          "Alternate - Songs",
+  suite name:          "Plain context - Songs",
         context:       WhiteBread.Example.PlainContext,
         feature_paths: ["features/"],
         tags:          ["songs"]

--- a/features/config.exs
+++ b/features/config.exs
@@ -10,7 +10,7 @@ defmodule WhiteBread.Example.Config do
         feature_paths: ["features/"]
 
   suite name:          "Alternate - Songs",
-        context:       WhiteBread.Example.AlternateContext,
+        context:       WhiteBread.Example.PlainContext,
         feature_paths: ["features/"],
         tags:          ["songs"]
 end

--- a/features/contexts/plain_context.exs
+++ b/features/contexts/plain_context.exs
@@ -3,23 +3,23 @@ defmodule WhiteBread.Example.PlainContext do
 
   def get_steps do
     [
-      ContextFunction.new("I want more", fn _state , _extra ->
+      ContextFunction.new("I want more", fn _state ->
          {:ok, :want_more}
       end),
 
-      ContextFunction.new("I had a heart", fn :want_more, _extra ->
+      ContextFunction.new("I had a heart", fn :want_more ->
          {:ok, "have a heart"}
       end),
 
-      ContextFunction.new("I had a voice", fn :want_more, _extra ->
-        {:ok, "have a voice"}
+      ContextFunction.new("I had a voice", fn ->
+        # Arity zero funcs don't have to return anything
       end),
 
-      ContextFunction.new("I could love you", fn "have a heart", _extra ->
+      ContextFunction.new("I could love you", fn "have a heart" ->
         {:ok, :love}
       end),
 
-      ContextFunction.new("I would sing", fn "have a voice", _extra ->
+      ContextFunction.new(~r/^I would (?<action>[a-z]+)$/, fn _state, %{action: "sing"} ->
          {:ok, :singing}
       end)
     ]

--- a/features/contexts/plain_context.exs
+++ b/features/contexts/plain_context.exs
@@ -1,0 +1,40 @@
+defmodule WhiteBread.Example.PlainContext do
+  alias WhiteBread.Context.ContextFunction
+
+  def get_steps do
+    [
+      ContextFunction.new("I want more", fn _state , _extra ->
+         {:ok, :want_more}
+      end),
+
+      ContextFunction.new("I had a heart", fn :want_more, _extra ->
+         {:ok, "have a heart"}
+      end),
+
+      ContextFunction.new("I had a voice", fn :want_more, _extra ->
+        {:ok, "have a voice"}
+      end),
+
+      ContextFunction.new("I could love you", fn "have a heart", _extra ->
+        {:ok, :love}
+      end),
+
+      ContextFunction.new("I would sing", fn "have a voice", _extra ->
+         {:ok, :singing}
+      end)
+    ]
+
+  end
+
+  def feature_state() do
+      # Always default to an empty map
+      %{}
+  end
+
+  def starting_state(feature_state) do
+      feature_state
+  end
+
+  def finalize(_ignored_state), do: nil
+
+end

--- a/features/contexts/plain_context.exs
+++ b/features/contexts/plain_context.exs
@@ -1,25 +1,25 @@
 defmodule WhiteBread.Example.PlainContext do
-  alias WhiteBread.Context.StepFunction
+  alias WhiteBread.Step
 
   def get_steps do
     [
-      StepFunction.new("I want more", fn _state ->
+      Step.given_("I want more", fn _state ->
          {:ok, :want_more}
       end),
 
-      StepFunction.new("I had a heart", fn :want_more ->
+      Step.given_("I had a heart", fn :want_more ->
          {:ok, "have a heart"}
       end),
 
-      StepFunction.new("I had a voice", fn ->
+      Step.given_("I had a voice", fn ->
         # Arity zero funcs don't have to return anything
       end),
 
-      StepFunction.new("I could love you", fn "have a heart" ->
+      Step.then_("I could love you", fn "have a heart" ->
         {:ok, :love}
       end),
 
-      StepFunction.new(~r/^I would (?<action>[a-z]+)$/, fn _state, %{action: "sing"} ->
+      Step.then_(~r/^I would (?<action>[a-z]+)$/, fn _state, %{action: "sing"} ->
          {:ok, :singing}
       end)
     ]

--- a/features/contexts/plain_context.exs
+++ b/features/contexts/plain_context.exs
@@ -1,4 +1,5 @@
 defmodule WhiteBread.Example.PlainContext do
+  @behaviour WhiteBread.ContextBehaviour
   alias WhiteBread.Step
 
   def get_steps do

--- a/features/contexts/plain_context.exs
+++ b/features/contexts/plain_context.exs
@@ -1,25 +1,25 @@
 defmodule WhiteBread.Example.PlainContext do
-  alias WhiteBread.Context.ContextFunction
+  alias WhiteBread.Context.StepFunction
 
   def get_steps do
     [
-      ContextFunction.new("I want more", fn _state ->
+      StepFunction.new("I want more", fn _state ->
          {:ok, :want_more}
       end),
 
-      ContextFunction.new("I had a heart", fn :want_more ->
+      StepFunction.new("I had a heart", fn :want_more ->
          {:ok, "have a heart"}
       end),
 
-      ContextFunction.new("I had a voice", fn ->
+      StepFunction.new("I had a voice", fn ->
         # Arity zero funcs don't have to return anything
       end),
 
-      ContextFunction.new("I could love you", fn "have a heart" ->
+      StepFunction.new("I could love you", fn "have a heart" ->
         {:ok, :love}
       end),
 
-      ContextFunction.new(~r/^I would (?<action>[a-z]+)$/, fn _state, %{action: "sing"} ->
+      StepFunction.new(~r/^I would (?<action>[a-z]+)$/, fn _state, %{action: "sing"} ->
          {:ok, :singing}
       end)
     ]

--- a/lib/white_bread/context.ex
+++ b/lib/white_bread/context.ex
@@ -11,6 +11,8 @@ defmodule WhiteBread.Context do
       import WhiteBread.Context
       import ExUnit.Assertions
 
+      @behaviour WhiteBread.ContextBehaviour
+
       @steps []
 
       @sub_context_modules []

--- a/lib/white_bread/context/context_function.ex
+++ b/lib/white_bread/context/context_function.ex
@@ -4,7 +4,7 @@ defmodule WhiteBread.Context.ContextFunction do
             function: nil,
             type: nil
 
-  def new(%Regex{} = regex, func) do
+  def new(%Regex{} = regex, func) when is_function(func, 2) do
     %__MODULE__{
       regex: regex,
       function: func,
@@ -12,7 +12,7 @@ defmodule WhiteBread.Context.ContextFunction do
     }
   end
 
-  def new(string, func) do
+  def new(string, func) when is_function(func, 2) do
     %__MODULE__{
       string: string,
       function: func,

--- a/lib/white_bread/context/context_function.ex
+++ b/lib/white_bread/context/context_function.ex
@@ -20,6 +20,23 @@ defmodule WhiteBread.Context.ContextFunction do
     }
   end
 
+  # All stored funcs must be arity two
+  def new(match, func) when is_function(func, 1) do
+    wrapped_func = fn(state, _extra) ->
+      func.(state)
+    end
+    new(match, wrapped_func)
+  end
+
+  # All stored funcs must be arity two
+  def new(match, func) when is_function(func, 0) do
+    wrapped_func = fn(state, _extra) ->
+      func.()
+      {:ok, state}
+    end
+    new(match, wrapped_func)
+  end
+
   def type(%__MODULE__{type: type}) do
     type
   end

--- a/lib/white_bread/context/setup.ex
+++ b/lib/white_bread/context/setup.ex
@@ -1,6 +1,4 @@
 defmodule WhiteBread.Context.Setup do
-  alias WhiteBread.Context.StepExecutor
-
   def before do
     quote do
       def get_steps do

--- a/lib/white_bread/context/setup.ex
+++ b/lib/white_bread/context/setup.ex
@@ -3,11 +3,6 @@ defmodule WhiteBread.Context.Setup do
 
   def before do
     quote do
-      def execute_step(step, state) do
-        get_steps
-          |> StepExecutor.execute_step(step, state)
-      end
-
       def get_steps do
         @sub_context_modules
          |> Enum.map(fn(sub_module) -> apply(sub_module, :get_steps, []) end)

--- a/lib/white_bread/context/step_executor.ex
+++ b/lib/white_bread/context/step_executor.ex
@@ -1,12 +1,12 @@
 defmodule WhiteBread.Context.StepExecutor do
   alias WhiteBread.RegexExtension
   alias WhiteBread.Context.StepExecutor.ErrorHandler
-  alias WhiteBread.Context.ContextFunction
+  alias WhiteBread.Context.StepFunction
 
   def execute_step(steps, step, state) when is_list(steps) do
     try do
       step_func = find_match(steps, step.text)
-      case ContextFunction.type(step_func) do
+      case StepFunction.type(step_func) do
         :string -> apply_string_function(step_func, step, state)
         :regex -> apply_regex_function(step_func, step, state)
       end
@@ -22,7 +22,7 @@ defmodule WhiteBread.Context.StepExecutor do
 
   defp find_match(steps, step_text) do
     matches = steps
-      |> Stream.filter(&ContextFunction.match?(&1, step_text))
+      |> Stream.filter(&StepFunction.match?(&1, step_text))
       |> Enum.take(1)
     case matches do
       [match] -> match

--- a/lib/white_bread/context/step_function.ex
+++ b/lib/white_bread/context/step_function.ex
@@ -1,4 +1,4 @@
-defmodule WhiteBread.Context.ContextFunction do
+defmodule WhiteBread.Context.StepFunction do
   defstruct string: nil,
             regex: nil,
             function: nil,

--- a/lib/white_bread/context/step_macro_helpers.ex
+++ b/lib/white_bread/context/step_macro_helpers.ex
@@ -1,5 +1,5 @@
 defmodule WhiteBread.Context.StepMacroHelpers do
-  alias WhiteBread.Context.ContextFunction
+  alias WhiteBread.Context.StepFunction
 
   def add_func_to_steps(step_text, func_def) do
     fn_name = step_name(step_text)
@@ -11,7 +11,7 @@ defmodule WhiteBread.Context.StepMacroHelpers do
           is_function(func, 2) -> func.(state, extra)
         end
       end
-      new = ContextFunction.new(
+      new = StepFunction.new(
         unquote(step_text),
         &__MODULE__.unquote(fn_name)/2
       )
@@ -26,7 +26,7 @@ defmodule WhiteBread.Context.StepMacroHelpers do
         unquote(block)
         {:ok, state}
       end
-      new = ContextFunction.new(
+      new = StepFunction.new(
         unquote(step_text),
         &__MODULE__.unquote(fn_name)/2
       )

--- a/lib/white_bread/context_behaviour.ex
+++ b/lib/white_bread/context_behaviour.ex
@@ -1,0 +1,10 @@
+defmodule WhiteBread.ContextBehaviour do
+
+  @callback get_steps() :: [WhiteBread.Context.StepFunction.t]
+
+  @callback feature_state() :: any
+
+  @callback starting_state(any) :: any
+
+  @callback finalize(any) :: any
+end

--- a/lib/white_bread/runners/steps_runner.ex
+++ b/lib/white_bread/runners/steps_runner.ex
@@ -1,4 +1,6 @@
 defimpl WhiteBread.Runners, for: List do
+  alias WhiteBread.Context.StepExecutor
+
   def run(steps, context, setup) do
 
     starting_state = context
@@ -25,7 +27,8 @@ defimpl WhiteBread.Runners, for: List do
   end
 
   defp run_step(context, step, state) do
-    result = apply(context, :execute_step, [step, state])
+    possible_steps = apply(context, :get_steps, [])
+    result = StepExecutor.execute_step(possible_steps, step, state)
     case result do
       {:ok, state} -> {:ok, state}
       :ok          -> {:ok, state}

--- a/lib/white_bread/step.ex
+++ b/lib/white_bread/step.ex
@@ -1,0 +1,12 @@
+defmodule WhiteBread.Step do
+  alias WhiteBread.Context.StepFunction
+
+  def given_(text, func), do: StepFunction.new(text, func)
+  def when_(text, func),  do: StepFunction.new(text, func)
+  def then_(text, func),  do: StepFunction.new(text, func)
+  def and_(text, func),   do: StepFunction.new(text, func)
+  def but_(text, func),   do: StepFunction.new(text, func)
+
+  def _(text, func),      do: StepFunction.new(text, func)
+
+end

--- a/test/context/context_executor_test.exs
+++ b/test/context/context_executor_test.exs
@@ -1,0 +1,108 @@
+defmodule WhiteBread.Context.ContextExecutorTest do
+  use ExUnit.Case
+
+  alias WhiteBread.Context.StepExecutor
+  alias WhiteBread.Gherkin.Elements.Steps
+
+  alias WhiteBread.Context.ContextExecutorTest.ExampleContext
+
+  test "Blocks provided with a simple string return ok with the starting state" do
+    step = %Steps.Given{text: "I'm running a simple test"}
+    state = :old_state
+    possible_steps = ExampleContext.get_steps
+    assert StepExecutor.execute_step(possible_steps, step, state) == {:ok, state}
+  end
+
+  test "functions given with a simple string update and return the state" do
+    step = %Steps.When{text: "I pass in some state"}
+    state = :old_state
+    possible_steps = ExampleContext.get_steps
+    assert StepExecutor.execute_step(possible_steps, step, state) == {:ok, [:test_new_state | :old_state]}
+  end
+
+  test "steps can be provided with regexes rather than flat strings" do
+    state = :old_state
+    first_step = %Steps.Given{text: "I'm running a simple bakery"}
+    second_step = %Steps.When{text: "I pass in some pie"}
+
+    possible_steps = ExampleContext.get_steps
+    assert StepExecutor.execute_step(possible_steps, first_step, state) == {:ok, state}
+    assert StepExecutor.execute_step(possible_steps, second_step, state) == {:ok, state}
+  end
+
+  test "steps can can use named group capture" do
+    state = :old_state
+    step = %Steps.Then{text: "my new state should be awesome"}
+    possible_steps = ExampleContext.get_steps
+    assert StepExecutor.execute_step(possible_steps, step, state) == {:ok, "awesome"}
+  end
+
+  test "failing an assert should return a {%ExUnit.AssertionError{}, step, error} tuple" do
+    state = :old_state
+    step = %Steps.Then{text: "I will always fail"}
+    possible_steps = ExampleContext.get_steps
+    {result, ^step, _error} = StepExecutor.execute_step(possible_steps, step, state)
+    assert result.__struct__ == ExUnit.AssertionError
+  end
+
+  test "calling a missing step should return {:missing_step, step, MissingStep}" do
+    state = :old_state
+    step = %Steps.And{text: "I question if this step exists"}
+    possible_steps = ExampleContext.get_steps
+    result = StepExecutor.execute_step(possible_steps, step, state)
+    assert result == {:missing_step, step,  %WhiteBread.Context.MissingStep{message: "Step not defined"}}
+  end
+
+  test "calling a missing step with incorrect values {:no_clause_match, step, FunctionClauseError}" do
+    state = :wrong_state
+    step = %Steps.When{text: "I require a specific state"}
+    possible_steps = ExampleContext.get_steps
+    {failure, ^step, _}  = StepExecutor.execute_step(possible_steps, step, state)
+    assert failure == :no_clause_match
+  end
+
+  test "A step gets table_data passed as an option if available" do
+    table_data = [["Hello", "World"]]
+    step = %Steps.When{text: "I'm given the table:", table_data: table_data}
+    possible_steps = ExampleContext.get_steps
+    {:ok, returned_table_data}   = StepExecutor.execute_step(possible_steps, step, :whatever)
+    assert table_data == returned_table_data
+  end
+
+end
+
+defmodule WhiteBread.Context.ContextExecutorTest.ExampleContext do
+  use WhiteBread.Context
+
+  given_ "I'm running a simple test" do
+    # Nothing happening here
+  end
+
+  when_ "I pass in some state", fn state ->
+    {:ok, [:test_new_state | state]}
+  end
+
+  given_ ~r/I'm running a simple [A-Za-z]+/ do
+    # nothing happening here
+  end
+
+  when_ ~r/I pass in some [A-Za-z]+/, fn state ->
+    {:ok, state}
+  end
+
+  when_ "I require a specific state", fn :specific_state ->
+    {:ok, :new_state}
+  end
+
+  then_ ~r/my new state should be (?<new_state>[A-Za-z]+)/, fn _state, %{new_state: new_state} ->
+    {:ok, new_state}
+  end
+
+  when_ ~r/I'm given the table:/, fn _state, %{table_data: table_data} ->
+    {:ok, table_data}
+  end
+
+  then_ "I will always fail" do
+    assert 1 == 0
+  end
+end

--- a/test/context_test.exs
+++ b/test/context_test.exs
@@ -3,61 +3,6 @@ defmodule WhiteBread.ContextTest do
   alias WhiteBread.Gherkin.Elements.Steps, as: Steps
   alias WhiteBread.ContextTest.ExampleContext, as: ExampleContext
 
-  test "Blocks provided with a simple string return ok with the starting state" do
-    step = %Steps.Given{text: "I'm running a simple test"}
-    state = :old_state
-    assert ExampleContext.execute_step(step, state) == {:ok, state}
-  end
-
-  test "functions given with a simple string update and return the state" do
-    step = %Steps.When{text: "I pass in some state"}
-    state = :old_state
-    assert ExampleContext.execute_step(step, state) == {:ok, [:test_new_state | :old_state]}
-  end
-
-  test "steps can be provided with regexes rather than flat strings" do
-    state = :old_state
-    first_step = %Steps.Given{text: "I'm running a simple bakery"}
-    second_step = %Steps.When{text: "I pass in some pie"}
-
-    assert ExampleContext.execute_step(first_step, state) == {:ok, state}
-    assert ExampleContext.execute_step(second_step, state) == {:ok, state}
-  end
-
-  test "steps can can use named group capture" do
-    state = :old_state
-    step = %Steps.Then{text: "my new state should be awesome"}
-    assert ExampleContext.execute_step(step, state) == {:ok, "awesome"}
-  end
-
-  test "failing an assert should return a {%ExUnit.AssertionError{}, step, error} tuple" do
-    state = :old_state
-    step = %Steps.Then{text: "I will always fail"}
-    {result, ^step, _error} = ExampleContext.execute_step(step, state)
-    assert result.__struct__ == ExUnit.AssertionError
-  end
-
-  test "calling a missing step should return {:missing_step, step, MissingStep}" do
-    state = :old_state
-    step = %Steps.And{text: "I question if this step exists"}
-    result = ExampleContext.execute_step(step, state)
-    assert result == {:missing_step, step,  %WhiteBread.Context.MissingStep{message: "Step not defined"}}
-  end
-
-  test "calling a missing step with incorrect values {:no_clause_match, step, FunctionClauseError}" do
-    state = :wrong_state
-    step = %Steps.When{text: "I require a specific state"}
-    {failure, ^step, _} = ExampleContext.execute_step(step, state)
-    assert failure == :no_clause_match
-  end
-
-  test "A step gets table_data passed as an option if available" do
-    table_data = [["Hello", "World"]]
-    step = %Steps.When{text: "I'm given the table:", table_data: table_data}
-    {:ok, returned_table_data} = ExampleContext.execute_step(step, :whatever)
-    assert table_data == returned_table_data
-  end
-
   test "ExampleContext has 8 steps" do
      count = WhiteBread.ContextTest.ExampleContext.get_steps
       |> Enum.count

--- a/test/context_test.exs
+++ b/test/context_test.exs
@@ -1,7 +1,5 @@
 defmodule WhiteBread.ContextTest do
   use ExUnit.Case
-  alias WhiteBread.Gherkin.Elements.Steps, as: Steps
-  alias WhiteBread.ContextTest.ExampleContext, as: ExampleContext
 
   test "ExampleContext has 8 steps" do
      count = WhiteBread.ContextTest.ExampleContext.get_steps

--- a/test/sub_context_test.exs
+++ b/test/sub_context_test.exs
@@ -3,19 +3,8 @@ defmodule WhiteBread.SubContextTest do
   alias WhiteBread.Gherkin.Elements.Steps, as: Steps
   alias WhiteBread.SubContextTest.ExampleContext, as: ExampleContext
 
-  test "Blocks provided with a simple string return ok with the starting state" do
-    step = %Steps.Given{text: "I'm running a simple test"}
-    state = :old_state
-    assert ExampleContext.execute_step(step, state) == {:ok, state}
-  end
-
-  test "steps can be provided with regexes rather than flat strings" do
-    state = :old_state
-    first_step = %Steps.Given{text: "I'm running a simple bakery"}
-    second_step = %Steps.When{text: "I pass in some pie"}
-
-    assert ExampleContext.execute_step(first_step, state) == {:ok, state}
-    assert ExampleContext.execute_step(second_step, state) == {:ok, state}
+  test "All 3 steps in the sub contexts are returned" do
+    assert Enum.count(ExampleContext.get_steps) == 3
   end
 
 end

--- a/test/sub_context_test.exs
+++ b/test/sub_context_test.exs
@@ -1,6 +1,5 @@
 defmodule WhiteBread.SubContextTest do
   use ExUnit.Case
-  alias WhiteBread.Gherkin.Elements.Steps, as: Steps
   alias WhiteBread.SubContextTest.ExampleContext, as: ExampleContext
 
   test "All 3 steps in the sub contexts are returned" do


### PR DESCRIPTION
Although I like using the dsl I'm not sure I want to force or rely upon it.

This purpose of this PR is to ensure that plain elixir functions can be used to define a context.