### PR TITLE
Resolve async timeouts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,13 @@ otp_release:
 
 elixir:
   - 1.0.5
+  
   - 1.1.0
   - 1.2.1
+
+matrix:
+  allow_failures:
+    - elixir: 1.0.5
 
 script:
   - mix local.hex --force

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ If you want to run WhiteBread in test environment run this
 MIX_ENV=test mix white_bread.run
 ```
 
-To execute on each time WhiteBread in test environment without prefixing the command with `MIX_ENV=test`, you can also add this line in `mix.exs` 
+To execute on each time WhiteBread in test environment without prefixing the command with `MIX_ENV=test`, you can also add this line in `mix.exs`
 
 ```
 def project do
@@ -197,6 +197,48 @@ defmodule WhiteBread.Example.DefaultContext do
   #...
 end
 ```
+
+## Speeding things up - async running
+
+More than likely you have a multicore machine. To get things going a little
+faster each suite can be configured to run all features and scenarios in a
+separate process.
+
+This can be done by setting async to true on any suite:
+```elixir
+defmodule WhiteBread.Example.Config do
+  use WhiteBread.SuiteConfiguration
+
+  suite name:          "Speedy run",
+        context:       WhiteBread.Example.DefaultContext,
+        feature_paths: ["features/sub_dir_one"],
+        async: true
+end
+```
+note: At the moment each suite will be run sequentially in the order they appear
+in the config file.
+
+## Speeding things up - timeouts
+By default each scenario gets 30 seconds to execute. After which point it will
+fail with a timeout warning. Each context can define a custom timeout function:
+
+```elixir
+defmodule WhiteBread.Example.DefaultContext do
+  use WhiteBread.Context
+  scenario_timeouts fn _feature, scenario ->
+    case scenario.name do
+      "possible slow scenario" -> 60_000
+      _               -> 5000
+    end
+  end
+
+  # Rest of the context here as usual
+  #...
+end
+```
+This function gets the full structs representing the feature and scenario being
+executed so it's possible to base the decision to change the timeout on any
+available property: tags, name, description etc.
 
 # Public interface and BC breaks
 The public interface of this library covers:

--- a/lib/white_bread.ex
+++ b/lib/white_bread.ex
@@ -2,6 +2,10 @@ defmodule WhiteBread do
   alias WhiteBread.Outputers.ProgressReporter
   alias WhiteBread.Runners.FeatureRunner
 
+  # Features are capped to one hour. In practise the scenario's should be
+  # controlling the time out
+  @max_feature_run_time 1000 * 60 * 60
+
   def run(context, path, options \\ []) do
     tags = options |> Keyword.get(:tags)
     async = options |> Keyword.get(:async, false)
@@ -72,7 +76,7 @@ defmodule WhiteBread do
   defp run_all_features(features, context, output, async: true) do
     features
       |> Enum.map(&run_feature_async(&1, context, output))
-      |> Enum.map(&Task.await/1)
+      |> Enum.map(&Task.await(&1, @max_feature_run_time))
   end
 
   defp run_all_features(features, context, output, async: false) do

--- a/lib/white_bread/context.ex
+++ b/lib/white_bread/context.ex
@@ -21,6 +21,8 @@ defmodule WhiteBread.Context do
       @scenario_finalize_defined false
       @feature_state_definied false
 
+      @timeouts_definied false
+
       @before_compile WhiteBread.Context
     end
   end
@@ -70,6 +72,15 @@ defmodule WhiteBread.Context do
           is_function(unquote(function), 0)
             -> unquote(function).()
         end
+      end
+    end
+  end
+
+  defmacro scenario_timeouts(function) do
+    quote do
+      @timeouts_definied true
+      def get_scenario_timeout(feature, scenario) do
+        unquote(function).(feature, scenario)
       end
     end
   end

--- a/lib/white_bread/context/setup.ex
+++ b/lib/white_bread/context/setup.ex
@@ -1,6 +1,9 @@
 defmodule WhiteBread.Context.Setup do
   def before do
     quote do
+      # 30 seconds max per scenario
+      @default_scenario_timeout 1000 * 30
+
       def get_steps do
         @sub_context_modules
          |> Enum.map(fn(sub_module) -> apply(sub_module, :get_steps, []) end)
@@ -26,7 +29,9 @@ defmodule WhiteBread.Context.Setup do
       end
 
       unless @timeouts_definied do
-        def get_scenario_timeout(feature, scenario), do: 5000
+        def get_scenario_timeout(_feature, _scenario) do
+          @default_scenario_timeout
+        end
       end
 
     end

--- a/lib/white_bread/context/setup.ex
+++ b/lib/white_bread/context/setup.ex
@@ -24,6 +24,10 @@ defmodule WhiteBread.Context.Setup do
       unless @scenario_finalize_defined do
         def finalize(_ignored_state), do: nil
       end
+
+      def get_scenario_timeout(_feature_name, _scenario_name) do
+        5000
+      end
     end
   end
 end

--- a/lib/white_bread/context/setup.ex
+++ b/lib/white_bread/context/setup.ex
@@ -25,9 +25,10 @@ defmodule WhiteBread.Context.Setup do
         def finalize(_ignored_state), do: nil
       end
 
-      def get_scenario_timeout(_feature_name, _scenario_name) do
-        5000
+      unless @timeouts_definied do
+        def get_scenario_timeout(feature, scenario), do: 5000
       end
+
     end
   end
 end

--- a/lib/white_bread/context_behaviour.ex
+++ b/lib/white_bread/context_behaviour.ex
@@ -6,5 +6,7 @@ defmodule WhiteBread.ContextBehaviour do
 
   @callback starting_state(any) :: any
 
+  @callback get_scenario_timeout(String.t, String.t) :: any
+
   @callback finalize(any) :: any
 end

--- a/lib/white_bread/context_behaviour.ex
+++ b/lib/white_bread/context_behaviour.ex
@@ -1,4 +1,6 @@
 defmodule WhiteBread.ContextBehaviour do
+  alias WhiteBread.Gherkin.Elements.Feature
+  alias WhiteBread.Gherkin.Elements.Scenario
 
   @callback get_steps() :: [WhiteBread.Context.StepFunction.t]
 
@@ -6,7 +8,7 @@ defmodule WhiteBread.ContextBehaviour do
 
   @callback starting_state(any) :: any
 
-  @callback get_scenario_timeout(String.t, String.t) :: any
+  @callback get_scenario_timeout(Feature.t, Scenario.t) :: number
 
   @callback finalize(any) :: any
 end

--- a/lib/white_bread/final_result_printer.ex
+++ b/lib/white_bread/final_result_printer.ex
@@ -46,6 +46,8 @@ defmodule WhiteBread.FinalResultPrinter do
     step_helper.text(failure_type, failing_step, fail_data)
   end
 
+  defp get_fail_reason(:timeout, _), do: "Scenario timed out waiting for result"
+
   defp get_fail_reason(_, _), do: "Ended in a not okay state"
 
   defp add_newline(string), do: string <> "\n"

--- a/lib/white_bread/runners/feature_runner.ex
+++ b/lib/white_bread/runners/feature_runner.ex
@@ -1,5 +1,8 @@
 defmodule WhiteBread.Runners.FeatureRunner do
 
+  #1 minute
+  @default_scenario_run_time 1000 * 60
+
   alias WhiteBread.Runners.Setup
   alias WhiteBread.Runners.ScenarioRunner
   alias WhiteBread.Runners.ScenarioOutlineRunner
@@ -33,7 +36,7 @@ defmodule WhiteBread.Runners.FeatureRunner do
     if async do
       scenarios
         |> Enum.map(&run_scenario_async(&1, context, setup_with_state))
-        |> Enum.map(&Task.await/1)
+        |> Enum.map(&scenario_await/1)
     else
       scenarios
         |> Enum.map(&run_scenario(&1, context, setup_with_state))
@@ -42,6 +45,10 @@ defmodule WhiteBread.Runners.FeatureRunner do
 
   defp run_scenario_async(scenario, context, setup) do
     Task.async fn -> run_scenario(scenario, context, setup) end
+  end
+
+  defp scenario_await(task) do
+    Task.await(task, @default_scenario_run_time)
   end
 
   defp run_scenario(%Scenario{} = scenario, context, setup) do

--- a/lib/white_bread/runners/feature_runner.ex
+++ b/lib/white_bread/runners/feature_runner.ex
@@ -1,8 +1,4 @@
 defmodule WhiteBread.Runners.FeatureRunner do
-
-  #1 minute
-  @default_scenario_run_time 1000 * 60
-
   alias WhiteBread.Runners.Setup
   alias WhiteBread.Runners.ScenarioRunner
   alias WhiteBread.Runners.ScenarioOutlineRunner
@@ -10,15 +6,12 @@ defmodule WhiteBread.Runners.FeatureRunner do
   alias WhiteBread.Gherkin.Elements.Scenario
   alias WhiteBread.Gherkin.Elements.ScenarioOutline
 
-  def run(feature, context, progress_reporter, async: async)
-  do
-    %{scenarios: scenarios, background_steps: background_steps} = feature
-
+  def run(feature, context, progress_reporter, async: async) do
     setup = Setup.new
       |> Map.put(:progress_reporter, progress_reporter)
-      |> Map.put(:background_steps, background_steps)
+      |> Map.put(:background_steps, feature.background_steps)
 
-    results = scenarios
+    results = feature
       |> run_all_scenarios_for_context(context, setup, async: async)
       |> flatten_any_result_lists
 
@@ -28,27 +21,35 @@ defmodule WhiteBread.Runners.FeatureRunner do
     }
   end
 
-  defp run_all_scenarios_for_context(scenarios, context, setup, async: async) do
+  defp run_all_scenarios_for_context(feature, context, setup, async: async) do
     starting_state = apply(context, :feature_state, [])
     setup_with_state = setup
       |> Map.put(:starting_state, starting_state)
 
     if async do
-      scenarios
-        |> Enum.map(&run_scenario_async(&1, context, setup_with_state))
+      feature.scenarios
+        |> Enum.map(&run_scenario_async(feature, &1, context, setup_with_state))
         |> Enum.map(&scenario_await/1)
     else
-      scenarios
+      feature.scenarios
         |> Enum.map(&run_scenario(&1, context, setup_with_state))
     end
   end
 
-  defp run_scenario_async(scenario, context, setup) do
-    Task.async fn -> run_scenario(scenario, context, setup) end
+  defp run_scenario_async(_feature, scenario, context, setup) do
+    {
+      scenario,
+      5000, #context.get_scenario_timeout(feature.name, scenario.name),
+      Task.async fn -> run_scenario(scenario, context, setup) end
+    }
   end
 
-  defp scenario_await(task) do
-    Task.await(task, @default_scenario_run_time)
+  defp scenario_await({scenario, timeout, task}) do
+    case Task.yield(task, timeout) do
+      {:ok, result}   -> result
+      {:exit, reason} -> {scenario, {:failed, reason}}
+      nil             -> {scenario, {:failed, :timeout}}
+    end
   end
 
   defp run_scenario(%Scenario{} = scenario, context, setup) do

--- a/lib/white_bread/runners/feature_runner.ex
+++ b/lib/white_bread/runners/feature_runner.ex
@@ -36,10 +36,10 @@ defmodule WhiteBread.Runners.FeatureRunner do
     end
   end
 
-  defp run_scenario_async(_feature, scenario, context, setup) do
+  defp run_scenario_async(feature, scenario, context, setup) do
     {
       scenario,
-      5000, #context.get_scenario_timeout(feature.name, scenario.name),
+      context.get_scenario_timeout(feature.name, scenario.name),
       Task.async fn -> run_scenario(scenario, context, setup) end
     }
   end

--- a/lib/white_bread/runners/feature_runner.ex
+++ b/lib/white_bread/runners/feature_runner.ex
@@ -39,7 +39,7 @@ defmodule WhiteBread.Runners.FeatureRunner do
   defp run_scenario_async(feature, scenario, context, setup) do
     {
       scenario,
-      context.get_scenario_timeout(feature.name, scenario.name),
+      context.get_scenario_timeout(feature, scenario),
       Task.async fn -> run_scenario(scenario, context, setup) end
     }
   end

--- a/mix.exs
+++ b/mix.exs
@@ -13,7 +13,8 @@ defmodule WhiteBread.Mixfile do
        licenses: ["MIT"],
        links: %{"GitHub" => "https://github.com/meadsteve/white-bread"},
        ],
-     version: "2.7.0",
+     version: "3.0.0",
+     elixir: "~> 1.1",
      aliases: aliases,
      deps: deps]
   end

--- a/test/runners/feature_runner_test.exs
+++ b/test/runners/feature_runner_test.exs
@@ -77,7 +77,7 @@ defmodule WhiteBread.Runners.FeatureRunnerTest do
       %Steps.When{text: "I take too long to execute"}
     ]
 
-    scenario = %Scenario{name: "test scenario", steps: steps}
+    scenario = %Scenario{name: "slow scenario", steps: steps}
     feature = %Feature{name: "test feature", scenarios: [scenario]}
 
     output = WhiteBread.Outputers.Console.start
@@ -113,6 +113,13 @@ end
 defmodule WhiteBread.FeatureRunnerTest.ExampleContext do
   use WhiteBread.Context
   alias WhiteBread.FeatureRunnerTest.GlobalCounter
+
+  scenario_timeouts fn _feature, scenario ->
+    case scenario.name do
+      "slow scenario" -> 1
+      _               -> 5000
+    end
+  end
 
   when_ "step one", fn _state ->
     {:ok, :step_one_complete}

--- a/test/runners/feature_runner_test.exs
+++ b/test/runners/feature_runner_test.exs
@@ -72,6 +72,24 @@ defmodule WhiteBread.Runners.FeatureRunnerTest do
     }
   end
 
+  test "timed out scenarios should be failed" do
+    steps = [
+      %Steps.When{text: "I take too long to execute"}
+    ]
+
+    scenario = %Scenario{name: "test scenario", steps: steps}
+    feature = %Feature{name: "test feature", scenarios: [scenario]}
+
+    output = WhiteBread.Outputers.Console.start
+    result = WhiteBread.Runners.FeatureRunner.run(feature, ExampleContext, output, async: true)
+    output |> WhiteBread.Outputers.Console.stop
+
+    assert result == %{
+      failures: [{scenario, {:failed, :timeout}}],
+      successes: []
+    }
+  end
+
   test "feature runner should run given scenarios only once" do
 
     WhiteBread.FeatureRunnerTest.GlobalCounter.start_link
@@ -111,6 +129,11 @@ defmodule WhiteBread.FeatureRunnerTest.ExampleContext do
   when_ "make a failing assestion", fn _state ->
     assert 1 == 0
     {:ok, :impossible}
+  end
+
+  when_ "I take too long to execute", fn _state ->
+    :timer.sleep(1000 * 60)
+    {:ok, :slow}
   end
 
   when_ "increment global counter", fn _state->


### PR DESCRIPTION
Fixes #52
Catches scenario taking longer than 30 seconds and records as failures. Also allows contexts to define custom function to set timeouts:
```elixir

defmodule WhiteBread.Example.DefaultContext do
   use WhiteBread.Context

   scenario_timeouts fn _feature, scenario ->
     case scenario.name do
       "possible slow scenario" -> 60_000
       _               -> 5000
     end
   end
 
   # Rest of the context here as usual
   #...
 end
```