### PR TITLE
Print details of the assertion error

### DIFF
--- a/lib/white_bread/formatter/failed_step.ex
+++ b/lib/white_bread/formatter/failed_step.ex
@@ -33,8 +33,17 @@ end
 defimpl WhiteBread.Formatter.FailedStep,
 for: [ESpec.AssertionError, ExUnit.AssertionError] do
   def text(_, step, assertion_failure) do
+    print_assertion_failure assertion_failure
     %{text: step_text} = step
     %{message: assestion_message} = assertion_failure
     "#{step_text}: #{assestion_message}"
+  end
+
+  defp print_assertion_failure(assertion_failure) do
+    msg = ExUnit.AssertionError.message(assertion_failure)
+    formatted = [:red | msg]
+                |> IO.ANSI.format(true)
+                |> IO.iodata_to_binary
+    IO.puts formatted
   end
 end


### PR DESCRIPTION
[@meadsteve This is just a suggestion, as I'm really new to Elixir and I'm not yet capable to understand how ExUnit in depth and make any valuable contribution.]

The issue was that while I'm asserting two maps being equal I can't really see what's wrong and only got the message: `Assertion with == failed` which is obviously limiting the use for BDD.