### PR TITLE
Finalize status information

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,8 @@ defmodule SunDoe.CoffeeShopContext do
     state
   end
 
-  scenario_finalize fn state ->
+  # `_status` will be either {:ok, scenario} | {:error, reason, scenario}
+  scenario_finalize fn _status, state ->
     state.in_memory_coffee_db |> shutdown_db
   end
 

--- a/features/contexts/alternate_context.exs
+++ b/features/contexts/alternate_context.exs
@@ -11,7 +11,7 @@ defmodule WhiteBread.Example.AlternateContext do
     feature_state |> Dict.put(:starting_state_loaded, :yes)
   end
 
-  scenario_finalize fn _state ->
+  scenario_finalize fn _status, _state ->
     # Do some finalization actions
   end
 

--- a/features/contexts/default_context.exs
+++ b/features/contexts/default_context.exs
@@ -15,7 +15,7 @@ defmodule WhiteBread.Example.DefaultContext do
     feature_state |> Dict.put(:starting_state_loaded, :yes)
   end
 
-  scenario_finalize fn _state ->
+  scenario_finalize fn _status, _state ->
     # Do some finalization actions
   end
 

--- a/features/contexts/my_other_feature_b_context.exs
+++ b/features/contexts/my_other_feature_b_context.exs
@@ -11,7 +11,7 @@ defmodule WhiteBread.TestContextPerFeature.MyOtherFeatureBContext do
     feature_state |> Dict.put(:starting_state_loaded, :yes)
   end
 
-  scenario_finalize fn _state ->
+  scenario_finalize fn _status, _state ->
     # Do some finalization actions
   end
 

--- a/features/contexts/plain_context.exs
+++ b/features/contexts/plain_context.exs
@@ -36,7 +36,7 @@ defmodule WhiteBread.Example.PlainContext do
       feature_state
   end
 
-  def scenario_finalize(_ignored_state), do: nil
-  def feature_finalize(_ignored_state), do: nil
+  def scenario_finalize(_ignored_status, _ignored_state), do: nil
+  def feature_finalize(_ignored_status, _ignored_state), do: nil
 
 end

--- a/lib/white_bread/context.ex
+++ b/lib/white_bread/context.ex
@@ -66,7 +66,7 @@ defmodule WhiteBread.Context do
   defmacro scenario_finalize(function) do
     quote do
       @scenario_finalize_defined true
-      def scenario_finalize(status, state) do
+      def scenario_finalize(status \\ nil, state) do
         cond do
           is_function(unquote(function), 2)
             -> unquote(function).(status, state)
@@ -82,7 +82,7 @@ defmodule WhiteBread.Context do
   defmacro feature_finalize(function) do
     quote do
       @feature_finalize_defined true
-      def feature_finalize(status, state) do
+      def feature_finalize(status \\ nil, state) do
         cond do
           is_function(unquote(function), 2)
             -> unquote(function).(status, state)

--- a/lib/white_bread/context.ex
+++ b/lib/white_bread/context.ex
@@ -66,8 +66,10 @@ defmodule WhiteBread.Context do
   defmacro scenario_finalize(function) do
     quote do
       @scenario_finalize_defined true
-      def scenario_finalize(state) do
+      def scenario_finalize(status, state) do
         cond do
+          is_function(unquote(function), 2)
+            -> unquote(function).(status, state)
           is_function(unquote(function), 1)
             -> unquote(function).(state)
           is_function(unquote(function), 0)
@@ -80,8 +82,10 @@ defmodule WhiteBread.Context do
   defmacro feature_finalize(function) do
     quote do
       @feature_finalize_defined true
-      def feature_finalize(state) do
+      def feature_finalize(status, state) do
         cond do
+          is_function(unquote(function), 2)
+            -> unquote(function).(status, state)
           is_function(unquote(function), 1)
             -> unquote(function).(state)
           is_function(unquote(function), 0)

--- a/lib/white_bread/context/setup.ex
+++ b/lib/white_bread/context/setup.ex
@@ -25,11 +25,11 @@ defmodule WhiteBread.Context.Setup do
       end
 
       unless @scenario_finalize_defined do
-        def scenario_finalize(_ignored_state), do: nil
+        def scenario_finalize(_ignored_status, _ignored_state), do: nil
       end
 
       unless @feature_finalize_defined do
-        def feature_finalize(_ignored_state), do: nil
+        def feature_finalize(_ignored_status, _ignored_state), do: nil
       end
 
       unless @timeouts_definied do

--- a/lib/white_bread/context_behaviour.ex
+++ b/lib/white_bread/context_behaviour.ex
@@ -6,11 +6,11 @@ defmodule WhiteBread.ContextBehaviour do
 
   @callback feature_starting_state() :: any
 
-  @callback feature_finalize(any) :: any
+  @callback feature_finalize(atom, any) :: any
 
   @callback scenario_starting_state(any) :: any
 
-  @callback scenario_finalize(any) :: any
+  @callback scenario_finalize(atom, any) :: any
 
   @callback get_scenario_timeout(Feature.t, Scenario.t) :: number
 

--- a/lib/white_bread/runners/feature_runner.ex
+++ b/lib/white_bread/runners/feature_runner.ex
@@ -13,7 +13,6 @@ defmodule WhiteBread.Runners.FeatureRunner do
 
     results = feature
       |> run_all_scenarios_for_context(context, setup, async: async)
-      |> flatten_any_result_lists
 
     %{
       successes: results |> Enum.filter(&success?/1),
@@ -35,7 +34,9 @@ defmodule WhiteBread.Runners.FeatureRunner do
         |> Enum.map(&run_scenario(&1, context, setup_with_state))
     end
 
-    apply(context, :feature_finalize, [starting_state])
+    results = results |> flatten_any_result_lists()
+    status = if Enum.any?(results, &failure?/1), do: :error, else: :ok
+    apply(context, :feature_finalize, [status, starting_state])
 
     results
   end

--- a/lib/white_bread/runners/scenario_outline_runner.ex
+++ b/lib/white_bread/runners/scenario_outline_runner.ex
@@ -7,7 +7,7 @@ defmodule WhiteBread.Runners.ScenarioOutlineRunner do
   def run(scenario_outline, context, %Setup{} = setup \\ Setup.new) do
     scenario_outline
       |> build_each_example
-      |> Enum.map(&run_steps(&1, context, setup))
+      |> Enum.map(&run_steps(&1, scenario_outline, context, setup))
       |> process_results(scenario_outline)
       |> report_progress(setup, scenario_outline)
   end
@@ -36,9 +36,9 @@ defmodule WhiteBread.Runners.ScenarioOutlineRunner do
       |> Enum.reduce(starting_step, &replace_in_step/2)
   end
 
-  defp run_steps(steps, context, %Setup{} = setup) when is_list(steps) do
+  defp run_steps(steps, scenario_outline, context, %Setup{} = setup) when is_list(steps) do
      StepsRunner.run(
-      steps, context, setup.background_steps, setup.starting_state
+      {scenario_outline, steps}, context, setup.background_steps, setup.starting_state
      )
   end
 

--- a/lib/white_bread/runners/scenario_runner.ex
+++ b/lib/white_bread/runners/scenario_runner.ex
@@ -10,7 +10,7 @@ defmodule WhiteBread.Runners.ScenarioRunner do
     starting_state = setup.starting_state
       |> apply_scenario_starting_state(context)
 
-    scenario.steps
+    {scenario, scenario.steps}
       |> StepsRunner.run(context, setup.background_steps, starting_state)
       |> update_result_with_exits
       |> stop_trapping_exits

--- a/lib/white_bread/runners/steps_runner.ex
+++ b/lib/white_bread/runners/steps_runner.ex
@@ -1,13 +1,13 @@
 defmodule WhiteBread.Runners.StepsRunner do
   alias WhiteBread.Context.StepExecutor
 
-  def run(steps, context, background_steps, starting_state)
-  when is_list(steps) and is_list(background_steps)
+  def run({scenario, steps}, context, background_steps, starting_state)
+  when is_list(background_steps)
   do
     background_steps
       |> Enum.concat(steps)
       |> Enum.reduce({:ok, starting_state}, step_executor(context))
-      |> finalize(context)
+      |> finalize(context, scenario)
   end
 
   defp step_executor(context) do
@@ -29,12 +29,12 @@ defmodule WhiteBread.Runners.StepsRunner do
     end
   end
 
-  defp finalize(result = {:ok, state}, context) do
-    context.scenario_finalize(state)
+  defp finalize(result = {:ok, state}, context, scenario) do
+    context.scenario_finalize({:ok, scenario}, state)
     result
   end
-  defp finalize({error_result, state}, context) do
-    context.scenario_finalize(state)
+  defp finalize({error_result, state}, context, scenario) do
+    context.scenario_finalize({:error, error_result, scenario}, state)
     error_result
   end
 


### PR DESCRIPTION
So I set out to try to automatically take a screenshot on scenario failure, but it doesn't seem like its possible to know that information on `scenario_failure` of if it was successful or not.

So this PR adds the following capability:

```elixir
scenario_finalize fn
  {:ok, _scenario}, _state ->
        Hound.end_session
  {:error, _reason, scenario}, _state ->
    Hound.Helpers.Screenshot.take_screenshot("#{scenario.name |> String.downcase() |> String.replace(~r/\W/, "-")}-failure.png")
    Hound.end_session
end
```

Its backwards compatible allowing the regular single parameter function to still work as it does today.