### PR TITLE
Interpolate placeholders in tables

### DIFF
--- a/features/contexts/outline_context.exs
+++ b/features/contexts/outline_context.exs
@@ -70,7 +70,7 @@ defmodule WhiteBread.Example.OutlineContext.TableSteps do
 
   then_ ~r/^the table data should (?<negation>not )?contain "(?<string>[^"]+)"$/,
   fn %{table_data: table_data} = state, %{negation: negation, string: string} ->
-    contains = (for %{data: data} <- table_data, do: data) |> Enum.any?(&contains?(&1, string))
+    contains = Enum.map(table_data, &Map.values/1) |> List.flatten |> Enum.any?(&contains?(&1, string))
     assert contains == (String.length(negation) == 0)
     {:ok, state}
   end

--- a/features/contexts/outline_context.exs
+++ b/features/contexts/outline_context.exs
@@ -3,6 +3,7 @@ defmodule WhiteBread.Example.OutlineContext do
 
   import_steps_from WhiteBread.Example.OutlineContext.AdditionalStateSteps
   import_steps_from WhiteBread.Example.OutlineContext.StringSteps
+  import_steps_from WhiteBread.Example.OutlineContext.TableSteps
 
   feature_starting_state fn  ->
     %{feature_state_loaded: :yes}
@@ -55,6 +56,22 @@ defmodule WhiteBread.Example.OutlineContext.StringSteps do
 
   then_ ~r/^the string should contain "(?<substring>[^"]+)"$/, fn state, %{substring: substring} ->
     assert state[:string] |> contains?(substring)
+    {:ok, state}
+  end
+end
+
+defmodule WhiteBread.Example.OutlineContext.TableSteps do
+  use WhiteBread.Context
+  import String, only: [contains?: 2]
+
+  given_ "I have the following table:", fn state, {:table_data, table_data} ->
+    {:ok, state |> put_in([:table_data], table_data)}
+  end
+
+  then_ ~r/^the table data should (?<negation>not )?contain "(?<string>[^"]+)"$/,
+  fn %{table_data: table_data} = state, %{negation: negation, string: string} ->
+    contains = (for %{data: data} <- table_data, do: data) |> Enum.any?(&contains?(&1, string))
+    assert contains == (String.length(negation) == 0)
     {:ok, state}
   end
 end

--- a/features/outline/outline_example.feature
+++ b/features/outline/outline_example.feature
@@ -29,3 +29,14 @@ Feature: Scenario outlines
       | state |
       | foo   |
       | bar   |
+
+  Scenario Outline: Interpolate placeholders in tables
+    Given I have the following table:
+      | data          |
+      | <placeholder> |
+    Then the table data should contain "<placeholder>"
+    But the table data should not contain "placeholder"
+
+    Examples:
+      | placeholder |
+      | real value  |

--- a/features/outline/outline_example.feature
+++ b/features/outline/outline_example.feature
@@ -32,11 +32,12 @@ Feature: Scenario outlines
 
   Scenario Outline: Interpolate placeholders in tables
     Given I have the following table:
-      | data          |
-      | <placeholder> |
-    Then the table data should contain "<placeholder>"
-    But the table data should not contain "placeholder"
+      | one             | two             |
+      | <placeholder_1> | <placeholder_2> |
+    Then the table data should contain "<placeholder_1>"
+    And the table data should contain "<placeholder_2>"
+    But the table data should not contain "<placeholder"
 
     Examples:
-      | placeholder |
-      | real value  |
+      | placeholder_1 | placeholder_2 |
+      | real value 1  | real value 2  |

--- a/lib/white_bread/runners/scenario_outline_runner.ex
+++ b/lib/white_bread/runners/scenario_outline_runner.ex
@@ -50,8 +50,8 @@ defmodule WhiteBread.Runners.ScenarioOutlineRunner do
     placeholder = "<#{to_string(replace)}>"
     updated_text = initial_text
       |> String.replace(placeholder, with)
-    updated_table = for %{data: data} = row <- initial_table do
-      %{row | data: String.replace(data, placeholder, with)}
+    updated_table = for row <- initial_table do
+      Map.new row, fn {key, value} -> {key, String.replace(value, placeholder, with)} end
     end
     %{step | text: updated_text, table_data: updated_table}
   end

--- a/lib/white_bread/runners/scenario_outline_runner.ex
+++ b/lib/white_bread/runners/scenario_outline_runner.ex
@@ -46,10 +46,14 @@ defmodule WhiteBread.Runners.ScenarioOutlineRunner do
   end
 
   defp replace_in_step({replace, with}, step) do
-    %{text: initial} = step
-    updated_text = initial
-      |> String.replace("<#{to_string(replace)}>", with)
-    %{step | text: updated_text}
+    %{text: initial_text, table_data: initial_table} = step
+    placeholder = "<#{to_string(replace)}>"
+    updated_text = initial_text
+      |> String.replace(placeholder, with)
+    updated_table = for %{data: data} = row <- initial_table do
+      %{row | data: String.replace(data, placeholder, with)}
+    end
+    %{step | text: updated_text, table_data: updated_table}
   end
 
   defp report_progress(results, scenario_outline) do


### PR DESCRIPTION
&lt;Placeholders&gt; in tables within scenario outlines were being treated as literal text. I've fixed that.