### PR TITLE
Decouple from ExUnit

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,12 @@ def project do
 end
 ```
 
+## Integrating a testing library
+
+By default, `use WhiteBread.Context` will import ExUnit.Assertions. If you're not using ExUnit, you'll probably want to override this default by calling `use WhiteBread.Context, test_library: :some_other_library_name`.
+
+At the moment, the only library names available are `:ex_unit` (same as the default), `:espec`, and `nil` (which skips the test library setup step altogether).
+
 # Next steps - Additional Suites and subcontexts
 
 After following the getting started steps you may find your default context starts to get a bit large.

--- a/lib/white_bread/context.ex
+++ b/lib/white_bread/context.ex
@@ -8,24 +8,14 @@ defmodule WhiteBread.Context do
   @doc false
   defmacro __using__(opts \\ []) do
     opts = Keyword.merge [test_library: :ex_unit], opts
-
-    import_test_library = case opts[:test_library] do
-      :ex_unit -> quote do: import ExUnit.Assertions
-      :espec -> quote do
-        IO.puts "Getting ESpec!"
-        require ESpec
-        use ESpec
-      end
-      nil -> quote do: true
-      _ -> raise ArgumentError, ":test_library must be one of :ex_unit, :espec, or nil."
-    end
+    [test_library: test_library] = opts
 
     quote do
       IO.puts "Importing context into #{__MODULE__}"
       import WhiteBread.Context
 
       IO.puts "Importing test library #{inspect unquote(opts[:test_library])}."
-      unquote(import_test_library)
+      unquote(import_test_library test_library)
 
       IO.puts "Finishing setup."
       @behaviour WhiteBread.ContextBehaviour
@@ -127,5 +117,16 @@ defmodule WhiteBread.Context do
     end
   end
 
-
+  defp import_test_library(test_library) do
+    case test_library do
+      :ex_unit -> quote do: import ExUnit.Assertions
+      :espec -> quote do
+        IO.puts "Getting ESpec!"
+        require ESpec
+        use ESpec
+      end
+      nil -> quote do: true
+      _ -> raise ArgumentError, ":test_library must be one of :ex_unit, :espec, or nil."
+    end
+  end
 end

--- a/lib/white_bread/context.ex
+++ b/lib/white_bread/context.ex
@@ -9,16 +9,25 @@ defmodule WhiteBread.Context do
   defmacro __using__(opts \\ []) do
     opts = Keyword.merge [test_library: :ex_unit], opts
 
+    import_test_library = case opts[:test_library] do
+      :ex_unit -> quote do: import ExUnit.Assertions
+      :espec -> quote do
+        IO.puts "Getting ESpec!"
+        require ESpec
+        use ESpec
+      end
+      nil -> quote do: true
+      _ -> raise ArgumentError, ":test_library must be one of :ex_unit, :espec, or nil."
+    end
+
     quote do
+      IO.puts "Importing context into #{__MODULE__}"
       import WhiteBread.Context
 
-      case unquote(opts[:test_library]) do
-        :ex_unit -> import ExUnit.Assertions
-        :espec -> require ESpec; use ESpec
-        nil -> nil
-        _ -> raise ArgumentError, ":test_library must be one of :ex_unit, :espec, or nil."
-      end
+      IO.puts "Importing test library #{inspect unquote(opts[:test_library])}."
+      unquote(import_test_library)
 
+      IO.puts "Finishing setup."
       @behaviour WhiteBread.ContextBehaviour
 
       @steps []

--- a/lib/white_bread/context.ex
+++ b/lib/white_bread/context.ex
@@ -122,7 +122,7 @@ defmodule WhiteBread.Context do
         use ESpec
       end
       nil -> quote do: true
-      _ -> raise ArgumentError, ":test_library must be one of :ex_unit, :espec, or nil."
+      _ -> raise ArgumentError, "#{inspect test_library} is not a recognized value for :test_library. Recognized values are :ex_unit, :espec, and nil."
     end
   end
 end

--- a/lib/white_bread/context.ex
+++ b/lib/white_bread/context.ex
@@ -4,10 +4,11 @@ defmodule WhiteBread.Context do
   alias WhiteBread.Context.Setup
 
   @step_keywords [:given_, :when_, :then_, :and_, :but_]
+  @default_test_library :ex_unit
 
   @doc false
   defmacro __using__(opts \\ []) do
-    opts = Keyword.merge [test_library: :ex_unit], opts
+    opts = Keyword.merge [test_library: @default_test_library], opts
     [test_library: test_library] = opts
 
     quote do

--- a/lib/white_bread/context.ex
+++ b/lib/white_bread/context.ex
@@ -14,7 +14,7 @@ defmodule WhiteBread.Context do
 
       case unquote(opts[:test_library]) do
         :ex_unit -> import ExUnit.Assertions
-        :espec -> use ESpec
+        :espec -> require ESpec; use ESpec
         nil -> nil
         _ -> raise ArgumentError, ":test_library must be one of :ex_unit, :espec, or nil."
       end

--- a/lib/white_bread/context.ex
+++ b/lib/white_bread/context.ex
@@ -11,13 +11,9 @@ defmodule WhiteBread.Context do
     [test_library: test_library] = opts
 
     quote do
-      IO.puts "Importing context into #{__MODULE__}"
       import WhiteBread.Context
-
-      IO.puts "Importing test library #{inspect unquote(opts[:test_library])}."
       unquote(import_test_library test_library)
 
-      IO.puts "Finishing setup."
       @behaviour WhiteBread.ContextBehaviour
 
       @steps []
@@ -121,7 +117,6 @@ defmodule WhiteBread.Context do
     case test_library do
       :ex_unit -> quote do: import ExUnit.Assertions
       :espec -> quote do
-        IO.puts "Getting ESpec!"
         require ESpec
         use ESpec
       end

--- a/lib/white_bread/context.ex
+++ b/lib/white_bread/context.ex
@@ -15,6 +15,8 @@ defmodule WhiteBread.Context do
       case unquote(test_library) do
         :ex_unit -> import ExUnit.Assertions
         :espec -> use ESpec
+        nil -> nil
+        _ -> raise ArgumentError, ":test_library must be one of :ex_unit, :espec, or nil."
       end
 
       @behaviour WhiteBread.ContextBehaviour

--- a/lib/white_bread/context.ex
+++ b/lib/white_bread/context.ex
@@ -6,10 +6,16 @@ defmodule WhiteBread.Context do
   @step_keywords [:given_, :when_, :then_, :and_, :but_]
 
   @doc false
-  defmacro __using__(_opts) do
+  defmacro __using__(opts \\ []) do
+    opts = Keyword.merge [test_library: :ex_unit], opts
+
     quote do
       import WhiteBread.Context
-      import ExUnit.Assertions
+
+      case unquote(test_library) do
+        :ex_unit -> import ExUnit.Assertions
+        :espec -> use ESpec
+      end
 
       @behaviour WhiteBread.ContextBehaviour
 

--- a/lib/white_bread/context.ex
+++ b/lib/white_bread/context.ex
@@ -12,7 +12,7 @@ defmodule WhiteBread.Context do
     quote do
       import WhiteBread.Context
 
-      case unquote(test_library) do
+      case unquote(opts[:test_library]) do
         :ex_unit -> import ExUnit.Assertions
         :espec -> use ESpec
         nil -> nil


### PR DESCRIPTION
WhiteBread.Context brings in ExUnit.Assertions, which was conflicting with the ESpec functions that I want to use in my steps. So I made the test library configurable, defaulting to ExUnit.

Really, though, I only did it this way to avoid breaking existing behavior. In the longer term, I don't actually think that WhiteBread.Context should import a testing library at all out of the box. I'd rather see something like this:

```elixir
defmodule MyProject.Context
  defmacro __using__(_opts) do
    quote do
      use WhiteBread.Context # without testing library being loaded
      import ExUnit.Assertions
    end
  end
end
```
```elixir
defmodule MyProject.StepDefinitions
  use MyProject.Context
end
```

What do you think?