### PR TITLE
Fix version number

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## Unreleased changes
+
 ## 4.1.1 (2018-03-06)
 
 ### Enhancements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 4.1.1 (2018-03-06)
+
+### Enhancements
+None
+
+### Bug fixes
+- Placeholders are now interpolated in tables. Thanks to @marnen [#95]
+
+### Backwards incompatible changes
+- Placeholder interpolation might break tables that rely on < and > characters.
+
 ## 4.1.0 (2017-09-15)
 
 ### Enhancements
@@ -33,7 +44,7 @@ None
 none
 
 ### Backwards incompatible changes
-- The way custom output is configured has changed. Previously a config key `outputer` was expected to give a 
+- The way custom output is configured has changed. Previously a config key `outputer` was expected to give a
 module implementing the output protocol. This has now been replaced with an event driven model and the key `outputers`
 is now expected see #83 for details. This detail was not previously part of the official public interface.
 

--- a/mix.exs
+++ b/mix.exs
@@ -13,7 +13,7 @@ defmodule WhiteBread.Mixfile do
        licenses: ["MIT"],
        links: %{"GitHub" => "https://github.com/meadsteve/white-bread"},
        ],
-     version: "4.1.0",
+     version: "4.1.1",
      elixir: "~> 1.2",
      aliases: aliases(),
      deps: deps()]


### PR DESCRIPTION
Although the package was at 4.1.1, the mix.exs file and changelog still said 4.1.0, which was causing problems with some mix tasks. I updated them, and also added an "unreleased changes" section to the changelog so we can edit it as we go, rather than waiting for a release.