### PR TITLE
Fix arg parsing for `--suite <name>`

### DIFF
--- a/lib/mix/tasks/white_bread.run.ex
+++ b/lib/mix/tasks/white_bread.run.ex
@@ -13,7 +13,7 @@ defmodule Mix.Tasks.WhiteBread.Run do
 
   def run(argv) do
     {options, arguments, _} = argv
-    |> OptionParser.parse
+    |> OptionParser.parse(switches: [suite: :string])
     |> check_for_deprecations
 
     start_app(argv)


### PR DESCRIPTION
Without the `opts` param, the suite name is not properly parsed and the selected suite is not run, instead the first suite in the config is run.