### PR TITLE
Interpolate placeholders in table keys

### DIFF
--- a/features/contexts/outline_context.exs
+++ b/features/contexts/outline_context.exs
@@ -68,9 +68,22 @@ defmodule WhiteBread.Example.OutlineContext.TableSteps do
     {:ok, state |> put_in([:table_data], table_data)}
   end
 
-  then_ ~r/^the table data should (?<negation>not )?contain "(?<string>[^"]+)"$/,
+  then_ ~r/^the table data should (?<negation>not )?contain value "(?<string>[^"]+)"$/,
   fn %{table_data: table_data} = state, %{negation: negation, string: string} ->
     contains = Enum.map(table_data, &Map.values/1) |> List.flatten |> Enum.any?(&contains?(&1, string))
+    assert contains == (String.length(negation) == 0)
+    {:ok, state}
+  end
+
+  then_ ~r/^the table data should (?<negation>not )?contain key "(?<string>[^"]+)"$/,
+  fn %{table_data: table_data} = state, %{negation: negation, string: string} ->
+    contains =
+      table_data
+      |> Enum.map(&Map.keys/1)
+      |> List.flatten
+      |> Enum.map(&to_string/1)
+      |> Enum.any?(&contains?(&1, string))
+
     assert contains == (String.length(negation) == 0)
     {:ok, state}
   end

--- a/features/outline/outline_example.feature
+++ b/features/outline/outline_example.feature
@@ -30,14 +30,26 @@ Feature: Scenario outlines
       | foo   |
       | bar   |
 
-  Scenario Outline: Interpolate placeholders in tables
+  Scenario Outline: Interpolate placeholders in table values
     Given I have the following table:
       | one             | two             |
       | <placeholder_1> | <placeholder_2> |
-    Then the table data should contain "<placeholder_1>"
-    And the table data should contain "<placeholder_2>"
-    But the table data should not contain "<placeholder"
+    Then the table data should contain value "<placeholder_1>"
+    And the table data should contain value "<placeholder_2>"
+    But the table data should not contain value "<placeholder"
 
     Examples:
       | placeholder_1 | placeholder_2 |
       | real value 1  | real value 2  |
+
+  Scenario Outline: Interpolate placeholders in table keys
+    Given I have the following table:
+      | <key_placeholder_1> | <key_placeholder_2> |
+      | value_1             | value_2             |
+    Then the table data should contain key "<key_placeholder_1>"
+    And the table data should contain key "<key_placeholder_2>"
+    But the table data should not contain key "<key_placeholder"
+
+    Examples:
+      | key_placeholder_1 | key_placeholder_2 |
+      | real key 1        | real key 2        |

--- a/lib/white_bread/runners/scenario_outline_runner.ex
+++ b/lib/white_bread/runners/scenario_outline_runner.ex
@@ -50,9 +50,16 @@ defmodule WhiteBread.Runners.ScenarioOutlineRunner do
     placeholder = "<#{to_string(replace)}>"
     updated_text = initial_text
       |> String.replace(placeholder, with)
+
     updated_table = for row <- initial_table do
-      Map.new row, fn {key, value} -> {key, String.replace(value, placeholder, with)} end
+      for {key, value} <- row, into: %{} do
+        key = key |> Atom.to_string |> String.replace(placeholder, with) |> String.to_atom
+        value = String.replace(value, placeholder, with)
+
+        {key, value}
+      end
     end
+
     %{step | text: updated_text, table_data: updated_table}
   end
 


### PR DESCRIPTION
This change adds placeholders support for table keys. This functionality is useful when there is needed to parameterize table data key names in scenario outline.