### PR TITLE
Fix Elixir 1.8 compile warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ elixir:
   - 1.5
   - 1.6
   - 1.7
+  - 1.8
 
 matrix:
   exclude:
@@ -30,6 +31,10 @@ matrix:
       elixir: 1.4
     - otp_release: 21.0
       elixir: 1.5
+    - otp_release: 18.0
+      elixir: 1.8
+    - otp_release: 19.3
+      elixir: 1.8
 
 script:
   - mix local.hex --force

--- a/lib/white_bread/context/setup.ex
+++ b/lib/white_bread/context/setup.ex
@@ -8,7 +8,7 @@ defmodule WhiteBread.Context.Setup do
         @sub_context_modules
          |> Enum.map(fn(sub_module) -> apply(sub_module, :get_steps, []) end)
          |> Enum.flat_map(fn(x) -> x end)
-         |> Enum.into(@steps)
+         |> Kernel.++(@steps)
       end
 
       unless @feature_state_definied do

--- a/lib/white_bread/tags/feature_filterer.ex
+++ b/lib/white_bread/tags/feature_filterer.ex
@@ -4,7 +4,7 @@ defmodule WhiteBread.Tags.FeatureFilterer do
   def get_for_tags(features, tags) when is_list(features) do
     features
       |> filter(tags)
-      |> Enum.into(features_with_matching_scenarios(features, tags))
+      |> Kernel.++(features_with_matching_scenarios(features, tags))
   end
 
   defp features_with_matching_scenarios(features, tags) do


### PR DESCRIPTION
To fix the compile warnings when using Elixir 1.8, `Enum.into/2` was replace with `Kernel.++/2` when a non-empty list was being provided as second argument.